### PR TITLE
Add default to $header-font-family variable

### DIFF
--- a/scss/components/_type.scss
+++ b/scss/components/_type.scss
@@ -32,7 +32,7 @@ $body-line-height: 19px !default;
 
 /// Font family of headings.
 /// @type List
-$header-font-family: $global-font-family;
+$header-font-family: $global-font-family !default;
 
 /// Font size of `<h1>` elements.
 /// @type Number


### PR DESCRIPTION
Make it easy to override.