### PR TITLE
Add missing anchor for h6 selector

### DIFF
--- a/scss/components/_type.scss
+++ b/scss/components/_type.scss
@@ -198,7 +198,7 @@ h4 a,
 h4 a:visited,
 h5 a,
 h5 a:visited,
-h6,
+h6 a,
 h6 a:visited {
   color: $anchor-color;
 }


### PR DESCRIPTION
Keep the default color from inheriting the link color.